### PR TITLE
add numpy to virtualenv

### DIFF
--- a/Altiscale/runner.sh
+++ b/Altiscale/runner.sh
@@ -74,6 +74,7 @@ if [ "$SETUP" -eq "1" ]; then
     echo "Installing python packages"
     conda install -c conda-forge mrjob -y
     conda install nb_conda -y
+    conda install numpy -y
     conda install -c conda-forge -y notebook jupyter_contrib_nbextensions
     jupyter nbextension enable toc2/main
     echo "Configuring Jupyter Notebook environment"


### PR DESCRIPTION
This is so folks can ship the virtual environment with their mrjob so they can use python 2.7 and numpy.